### PR TITLE
Enable WASM proposals

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -88,6 +88,7 @@ import (
 	stargazeappparams "github.com/public-awesome/stargaze/app/params"
 
 	"github.com/CosmWasm/wasmd/x/wasm"
+	wasmclient "github.com/CosmWasm/wasmd/x/wasm/client"
 )
 
 const appName = "StargazeApp"
@@ -96,7 +97,7 @@ const appName = "StargazeApp"
 var (
 	// If EnabledSpecificProposals is "", and this is "true", then enable all x/wasm proposals.
 	// If EnabledSpecificProposals is "", and this is not "true", then disable all x/wasm proposals.
-	ProposalsEnabled = "false"
+	ProposalsEnabled = "true"
 	// If set to non-empty string it must be comma-separated list of values that are all a subset
 	// of "EnableAllProposals" (takes precedence over ProposalsEnabled)
 	EnableSpecificProposals = ""
@@ -135,10 +136,13 @@ var (
 		mint.AppModuleBasic{},
 		distr.AppModuleBasic{},
 		gov.NewAppModuleBasic(
-			paramsclient.ProposalHandler,
-			distrclient.ProposalHandler,
-			upgradeclient.ProposalHandler,
-			upgradeclient.CancelProposalHandler,
+			append(
+				wasmclient.ProposalHandlers,
+				paramsclient.ProposalHandler,
+				distrclient.ProposalHandler,
+				upgradeclient.ProposalHandler,
+				upgradeclient.CancelProposalHandler,
+			)...,
 		),
 		params.AppModuleBasic{},
 		crisis.AppModuleBasic{},
@@ -162,7 +166,13 @@ var (
 		stakingtypes.NotBondedPoolName: {authtypes.Burner, authtypes.Staking},
 		govtypes.ModuleName:            {authtypes.Burner},
 		ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
+		wasm.ModuleName:                {authtypes.Burner},
 	}
+
+	// // module accounts that are allowed to receive tokens
+	// allowedReceivingModAcc = map[string]bool{
+	// 	distrtypes.ModuleName: true,
+	// }
 )
 
 var (

--- a/app/app.go
+++ b/app/app.go
@@ -169,10 +169,10 @@ var (
 		wasm.ModuleName:                {authtypes.Burner},
 	}
 
-	// // module accounts that are allowed to receive tokens
-	// allowedReceivingModAcc = map[string]bool{
-	// 	distrtypes.ModuleName: true,
-	// }
+	// module accounts that are allowed to receive tokens
+	allowedReceivingModAcc = map[string]bool{
+		distrtypes.ModuleName: true,
+	}
 )
 
 var (
@@ -299,7 +299,7 @@ func NewStargazeApp(
 	)
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
 		appCodec, keys[banktypes.StoreKey], app.AccountKeeper, app.GetSubspace(banktypes.ModuleName),
-		app.ModuleAccountAddrs(),
+		app.BlockedAddrs(),
 	)
 	stakingKeeper := stakingkeeper.NewKeeper(
 		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.GetSubspace(stakingtypes.ModuleName),
@@ -573,6 +573,17 @@ func (app *StargazeApp) ModuleAccountAddrs() map[string]bool {
 	}
 
 	return modAccAddrs
+}
+
+// BlockedAddrs returns all the app's module account addresses that are not
+// allowed to receive external tokens.
+func (app *StargazeApp) BlockedAddrs() map[string]bool {
+	blockedAddrs := make(map[string]bool)
+	for acc := range maccPerms {
+		blockedAddrs[authtypes.NewModuleAddress(acc).String()] = !allowedReceivingModAcc[acc]
+	}
+
+	return blockedAddrs
 }
 
 // LegacyAmino returns SimApp's amino codec.


### PR DESCRIPTION
Adds the following new governance proposal types:
* clear-contract-admin: Submit a clear admin for a contract to prevent further migrations proposal
* instantiate-contract:    Submit an instantiate wasm contract proposal
* migrate-contract:        Submit a migrate wasm contract to a new code version proposal
* set-contract-admin:      Submit a new admin for a contract proposal
* wasm-store:              Submit a wasm binary proposal