### PR TITLE
remove tm rollback command

### DIFF
--- a/cmd/starsd/main.go
+++ b/cmd/starsd/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/public-awesome/stargaze/v4/cmd/starsd/cmd"
 	"github.com/spf13/cobra"
 	"github.com/tendermint/spm/cosmoscmd"
-	tmcmds "github.com/tendermint/tendermint/cmd/tendermint/commands"
 )
 
 func main() {
@@ -23,7 +22,6 @@ func main() {
 		cosmoscmd.AddSubCmd(cmd.TestnetCmd(app.ModuleBasics)),
 		cosmoscmd.AddCustomInitCmd(cmd.InitCmd(app.ModuleBasics, app.DefaultNodeHome)),
 		cosmoscmd.AddSubCmd(cmd.PrepareGenesisCmd(app.DefaultNodeHome, app.ModuleBasics)),
-		cosmoscmd.AddSubCmd(tmcmds.RollbackStateCmd),
 		cosmoscmd.CustomizeStartCmd(func(startCmd *cobra.Command) {
 			wasm.AddModuleInitFlags(startCmd)
 		}),


### PR DESCRIPTION
current sdk version contains it's own rollback version which does tm rollback + sdk store rollback 