### PR TITLE
Set block.max_gas in Docker entry-point.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build . -t publicawesome/stargaze:latest
 # docker run --rm -it publicawesome/stargaze:latest /bin/sh
-FROM golang:1.18.7-alpine3.15 AS go-builder
+FROM golang:1.19.3-alpine3.15 AS go-builder
 
 
 RUN set -eux; apk add --no-cache ca-certificates build-base git;

--- a/docker/Dockerfile.gaia
+++ b/docker/Dockerfile.gaia
@@ -1,4 +1,4 @@
-FROM golang:1.18.7-alpine3.15 AS go-builder
+FROM golang:1.19.3-alpine3.15 AS go-builder
 ARG TAG
 
 # Usage:

--- a/docker/Dockerfile.icad
+++ b/docker/Dockerfile.icad
@@ -1,4 +1,4 @@
-FROM golang:1.18.7-alpine3.15 AS go-builder
+FROM golang:1.19.3-alpine3.15 AS go-builder
 ARG TAG
 
 # Usage:

--- a/docker/Dockerfile.osmosis
+++ b/docker/Dockerfile.osmosis
@@ -1,4 +1,4 @@
-FROM golang:1.18.7-alpine3.15 AS go-builder
+FROM golang:1.19.3-alpine3.15 AS go-builder
 ARG TAG
 
 # Usage:

--- a/docker/entry-point.sh
+++ b/docker/entry-point.sh
@@ -2,6 +2,7 @@
 
 CHAINID=${CHAINID:-testing}
 DENOM=${DENOM:-ustars}
+BLOCK_GAS_LIMIT=${GAS_LIMIT:-75000000}
 
 # Build genesis file incl account for each address passed in
 coins="10000000000000000$DENOM"
@@ -23,6 +24,7 @@ starsd collect-gentxs
 sed -i 's/"leveldb"/"goleveldb"/g' ~/.starsd/config/config.toml
 sed -i 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ~/.starsd/config/config.toml
 sed -i "s/\"stake\"/\"$DENOM\"/g" ~/.starsd/config/genesis.json
+sed -i "s/\"max_gas\": \"-1\"/\"max_gas\": \"$BLOCK_GAS_LIMIT\"/" ~/.starsd/config/genesis.json
 sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' ~/.starsd/config/config.toml
 sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' ~/.starsd/config/config.toml
 sed -i 's/index_all_keys = false/index_all_keys = true/g' ~/.starsd/config/config.toml


### PR DESCRIPTION
The launchpad integration tests should have the same max_gas param as mainnet to catch out of gas errors.

I also ran into errors building the docker images because of the go 1.19 requirement.