### PR TITLE
Removing token denom hardcoding in antehandler

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	ibcante "github.com/cosmos/ibc-go/v3/modules/core/ante"
 	ibckeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
 	stargazeante "github.com/public-awesome/stargaze/v8/internal/ante"
@@ -17,6 +18,7 @@ import (
 type HandlerOptions struct {
 	ante.HandlerOptions
 	keeper            *ibckeeper.Keeper
+	govKeeper         govkeeper.Keeper
 	WasmConfig        *wasmTypes.WasmConfig
 	TXCounterStoreKey sdk.StoreKey
 	Codec             codec.BinaryCodec
@@ -56,7 +58,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		// limit simulation gas
 		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit),
 		stargazeante.NewMinCommissionDecorator(options.Codec),
-		stargazeante.NewMinDepositDecorator(options.Codec),
+		stargazeante.NewMinDepositDecorator(options.Codec, options.govKeeper),
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreKey),
 		ante.NewRejectExtensionOptionsDecorator(),
 		ante.NewMempoolFeeDecorator(),

--- a/app/app.go
+++ b/app/app.go
@@ -675,6 +675,7 @@ func NewStargazeApp(
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
 			keeper:            app.IBCKeeper,
+			govKeeper:         app.GovKeeper,
 			WasmConfig:        &wasmConfig,
 			TXCounterStoreKey: keys[wasm.StoreKey],
 			Codec:             app.appCodec,

--- a/internal/ante/min_deposit.go
+++ b/internal/ante/min_deposit.go
@@ -28,11 +28,13 @@ func (dec MinDepositDecorator) checkDeposit(ctx sdk.Context, m sdk.Msg) error {
 	switch msg := m.(type) {
 	case *govtypes.MsgSubmitProposal:
 		params := dec.govKeeper.GetDepositParams(ctx)
-		coinDenom := params.MinDeposit[0]
-		minDepositAmount := sdk.NewInt(1_000_000_000)
-		c := msg.GetInitialDeposit()
-		if c.AmountOf(coinDenom.Denom).LT(minDepositAmount) {
-			return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, fmt.Sprintf("min deposit cannot be lower than %s %s", minDepositAmount.String(), coinDenom.GetDenom()))
+		if len(params.MinDeposit) > 0 {
+			coinDenom := params.MinDeposit[0]
+			minDepositAmount := sdk.NewInt(1_000_000_000)
+			c := msg.GetInitialDeposit()
+			if c.AmountOf(coinDenom.Denom).LT(minDepositAmount) {
+				return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, fmt.Sprintf("min deposit cannot be lower than %s %s", minDepositAmount.String(), coinDenom.GetDenom()))
+			}
 		}
 	default:
 		return nil

--- a/internal/ante/min_deposit.go
+++ b/internal/ante/min_deposit.go
@@ -1,30 +1,38 @@
 package ante
 
 import (
+	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/cosmos/cosmos-sdk/x/authz"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
 type MinDepositDecorator struct {
-	codec codec.BinaryCodec
+	codec     codec.BinaryCodec
+	govKeeper govkeeper.Keeper
 }
 
-func NewMinDepositDecorator(codec codec.BinaryCodec) MinDepositDecorator {
+func NewMinDepositDecorator(codec codec.BinaryCodec, gk govkeeper.Keeper) MinDepositDecorator {
 	return MinDepositDecorator{
 		codec,
+		gk,
 	}
 }
 
-func (dec MinDepositDecorator) checkDeposit(m sdk.Msg) error {
+func (dec MinDepositDecorator) checkDeposit(ctx sdk.Context, m sdk.Msg) error {
 	switch msg := m.(type) {
 	case *govtypes.MsgSubmitProposal:
+		params := dec.govKeeper.GetDepositParams(ctx)
+		coinDenom := params.MinDeposit[0]
+		minDepositAmount := sdk.NewInt(1_000_000_000)
 		c := msg.GetInitialDeposit()
-		if c.AmountOf("ustars").LT(sdk.NewInt(1_000_000_000)) {
-			return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "min deposit cannot be lower than 1,000 STARS")
+		if c.AmountOf(coinDenom.Denom).LT(minDepositAmount) {
+			return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, fmt.Sprintf("min deposit cannot be lower than %s %s", minDepositAmount.String(), coinDenom.GetDenom()))
 		}
 	default:
 		return nil
@@ -32,8 +40,8 @@ func (dec MinDepositDecorator) checkDeposit(m sdk.Msg) error {
 	return nil
 }
 
-func (dec MinDepositDecorator) Validate(m sdk.Msg) error {
-	err := dec.checkDeposit(m)
+func (dec MinDepositDecorator) Validate(ctx sdk.Context, m sdk.Msg) error {
+	err := dec.checkDeposit(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -44,7 +52,7 @@ func (dec MinDepositDecorator) Validate(m sdk.Msg) error {
 			if err != nil {
 				return sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "error decoding authz messages")
 			}
-			err = dec.checkDeposit(wrappedMsg)
+			err = dec.checkDeposit(ctx, wrappedMsg)
 			if err != nil {
 				return err
 			}
@@ -59,7 +67,7 @@ func (dec MinDepositDecorator) AnteHandle(
 ) (newCtx sdk.Context, err error) {
 	msgs := tx.GetMsgs()
 	for _, m := range msgs {
-		err := dec.Validate(m)
+		err := dec.Validate(ctx, m)
 		if err != nil {
 			return ctx, err
 		}

--- a/internal/ante/min_deposit_test.go
+++ b/internal/ante/min_deposit_test.go
@@ -1,6 +1,7 @@
 package ante_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -25,7 +26,7 @@ func TestMinDepositDecorator(t *testing.T) {
 	pub2 := secp256k1.GenPrivKey().PubKey()
 	addr2 := sdk.AccAddress(pub2.Address())
 
-	genTokens := sdk.TokensFromConsensusPower(42, sdk.DefaultPowerReduction)
+	genTokens := sdk.TokensFromConsensusPower(1000, sdk.DefaultPowerReduction)
 	bondTokens := sdk.TokensFromConsensusPower(10, sdk.DefaultPowerReduction)
 	genCoin := sdk.NewCoin(sdk.DefaultBondDenom, genTokens)
 	stars := sdk.NewCoin("ustars", sdk.NewInt(5_000_000_000))
@@ -56,9 +57,9 @@ func TestMinDepositDecorator(t *testing.T) {
 	encoding := cosmoscmd.MakeEncodingConfig(stargazeapp.ModuleBasics)
 	txGen := encoding.TxConfig
 	_, _, err = simapp.SignCheckDeliver(t, txGen, app.BaseApp, header, []sdk.Msg{createProposalMsg}, "", []uint64{0}, []uint64{0}, true, false, false, priv1)
-	require.EqualError(t, err, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "min deposit cannot be lower than 1,000 STARS").Error())
+	require.EqualError(t, err, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, fmt.Sprintf("min deposit cannot be lower than %d %s", 1_000_000_000, sdk.DefaultBondDenom)).Error())
 
-	createProposalMsg, err = govtypes.NewMsgSubmitProposal(content, sdk.NewCoins(sdk.NewInt64Coin("ustars", 1_000_000_000)), addr1)
+	createProposalMsg, err = govtypes.NewMsgSubmitProposal(content, sdk.NewCoins(sdk.NewInt64Coin(sdk.DefaultBondDenom, 1_000_000_000)), addr1)
 	require.NoError(t, err)
 
 	header = tmproto.Header{Height: app.LastBlockHeight() + 1}


### PR DESCRIPTION
In the antehandler which checks for mininum deposit amount sent during `submit-proposal` the deposit token denom was hardcoded to `ustars`  (Ref: #712)

This causes issues when running the chain locally as the local instance has `stake` as the chain denom.

Changes in this PR include modification to the `MinDepositDecorator` antehandler to use the Deposit params from the gov keeper to get the denom name to check for the min-deposit value