### PR TITLE
fix: swagger generation for sdk47 proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,4 +179,6 @@ proto-format:
 	find ./ -name *.proto -exec clang-format -i {} \;
 
 proto-swagger-gen:
-	@./scripts/protoc-swagger-gen.sh
+	$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(PROTO_BUILDER_IMAGE) sh ./scripts/protoc-swagger-gen.sh
+	docker run --rm -v "${PWD}":/workdir mikefarah/yq -p yaml -o json ./docs/static/swagger.yaml > ./docs/static/swagger.json
+	rm docs/static/swagger.yaml

--- a/app/app.go
+++ b/app/app.go
@@ -993,8 +993,8 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiCfg config.APIConfig) {
 
 	// register app's OpenAPI routes.
 	if apiCfg.Swagger {
-		apiSvr.Router.Handle("/static/openapi.yml", http.FileServer(http.FS(docs.Docs)))
-		apiSvr.Router.HandleFunc("/", openapiconsole.Handler(Name, "/static/openapi.yml"))
+		apiSvr.Router.Handle("/static/swagger.json", http.FileServer(http.FS(docs.Docs)))
+		apiSvr.Router.HandleFunc("/", openapiconsole.Handler(Name, "/static/swagger.json"))
 	}
 
 	apiSvr.Router.Handle("/stargaze/wasm/smart", stargazerest.BatchedQuerierHandler(clientCtx))

--- a/app/app.go
+++ b/app/app.go
@@ -980,7 +980,7 @@ func (app *App) GetSubspace(moduleName string) paramstypes.Subspace {
 
 // RegisterAPIRoutes registers all application module routes with the provided
 // API server.
-func (app *App) RegisterAPIRoutes(apiSvr *api.Server, _ config.APIConfig) {
+func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiCfg config.APIConfig) {
 	clientCtx := apiSvr.ClientCtx
 	// Register new tx routes from grpc-gateway.
 	authtx.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
@@ -992,8 +992,10 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, _ config.APIConfig) {
 	ModuleBasics.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 
 	// register app's OpenAPI routes.
-	apiSvr.Router.Handle("/static/openapi.yml", http.FileServer(http.FS(docs.Docs)))
-	apiSvr.Router.HandleFunc("/", openapiconsole.Handler(Name, "/static/openapi.yml"))
+	if apiCfg.Swagger {
+		apiSvr.Router.Handle("/static/openapi.yml", http.FileServer(http.FS(docs.Docs)))
+		apiSvr.Router.HandleFunc("/", openapiconsole.Handler(Name, "/static/openapi.yml"))
+	}
 
 	apiSvr.Router.Handle("/stargaze/wasm/smart", stargazerest.BatchedQuerierHandler(clientCtx))
 }

--- a/proto/buf.gen.swagger.yaml
+++ b/proto/buf.gen.swagger.yaml
@@ -1,0 +1,5 @@
+version: v1
+plugins:
+  - name: swagger
+    out: ../tmp-swagger-gen
+    opt: logtostderr=true,fqn_for_swagger_name=true,simple_operation_ids=true

--- a/scripts/protoc-swagger-gen.sh
+++ b/scripts/protoc-swagger-gen.sh
@@ -2,24 +2,40 @@
 
 set -eo pipefail
 
-mkdir -p ./docs/client
+mkdir -p ./tmp-swagger-gen
+cd proto
 
-# Get the path of the cosmos-sdk repo from go/pkg/mod
-cosmos_sdk_dir=$(go list -f '{{ .Dir }}' -m github.com/cosmos/cosmos-sdk)
+proto_dirs=$(find ./publicawesome -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 
-proto_dirs=$(find ./proto "$cosmos_sdk_dir"/proto -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   # generate swagger files (filter query files)
   query_file=$(find "${dir}" -maxdepth 1 \( -name 'query.proto' -o -name 'service.proto' \))
   if [[ ! -z "$query_file" ]]; then
-    protoc  \
-    -I "proto" \
-    -I "$cosmos_sdk_dir/third_party/proto" \
-    -I "$cosmos_sdk_dir/proto" \
-      "$query_file" \
-    --swagger_out=./docs/client \
-    --swagger_opt logtostderr=true \
-    --swagger_opt fqn_for_swagger_name=true \
-    --swagger_opt simple_operation_ids=true
+    buf generate --template buf.gen.swagger.yaml $query_file
   fi
 done
+
+cd ..
+
+# Fetching the stargaze version to tag in the swagger doc
+stargazeTemplate="{stargaze-version}"
+stargazeVersion=$(echo $(git describe --tags) | sed 's/^v//')
+sed "s/$stargazeTemplate/$stargazeVersion/g" ./docs/config.json > ./tmp-swagger-gen/config.json
+
+# Fetching the cosmos-sdk version to use the appropriate swagger file
+sdkTemplate="{sdk-version}"
+sdkVersion=$(go list -m -f '{{ .Version }}' github.com/cosmos/cosmos-sdk)
+sed -i "s/$sdkTemplate/$sdkVersion/g" ./tmp-swagger-gen/config.json
+
+# Fetching the wasmd version to use the appropriate swagger file
+wasmdTemplate="{wasmd-version}"
+wasmdVersion=$(go list -m -f '{{ .Version }}' github.com/CosmWasm/wasmd)
+sed -i "s/$wasmdTemplate/$wasmdVersion/g" ./tmp-swagger-gen/config.json
+
+# combine swagger files
+# uses nodejs package `swagger-combine`.
+# all the individual swagger files need to be configured in `config.json` for merging
+swagger-combine ./tmp-swagger-gen/config.json -o ./docs/static/swagger.yaml -f yaml --includeDefinitions true
+
+# clean swagger files
+rm -rf ./tmp-swagger-gen


### PR DESCRIPTION
With changing of proto works with new sdk, the existing swagger gen does not work.
Updated to fix it.

Using json instead of yaml as the `swagger-combine` output doesn't seem to work. 