### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/x/cron/keeper/params.go
+++ b/x/cron/keeper/params.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"slices"
+	
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/public-awesome/stargaze/v15/x/cron/types"
 )
@@ -21,10 +23,5 @@ func (k Keeper) IsAdminAddress(ctx sdk.Context, address string) bool {
 		return false
 	}
 	privilegedAddresses := params.AdminAddresses
-	for _, paddr := range privilegedAddresses {
-		if address == paddr {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(privilegedAddresses, address)
 }

--- a/x/globalfee/keeper/params.go
+++ b/x/globalfee/keeper/params.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"slices"
+	
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/public-awesome/stargaze/v15/x/globalfee/types"
 )
@@ -21,10 +23,5 @@ func (k Keeper) IsPrivilegedAddress(ctx sdk.Context, address string) bool {
 		return false
 	}
 	privilegedAddresses := params.PrivilegedAddresses
-	for _, paddr := range privilegedAddresses {
-		if address == paddr {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(privilegedAddresses, address)
 }


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.