### PR TITLE
fix in query.pb.go

### DIFF
--- a/x/globalfee/types/query.pb.go
+++ b/x/globalfee/types/query.pb.go
@@ -245,7 +245,7 @@ func (m *QueryParamsRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryParamsRequest proto.InternalMessageInfo
 
-// QueryParamsResponse is the resposne for getting module's params.
+// QueryParamsResponse is the response for getting module's params.
 type QueryParamsResponse struct {
 	Params *Params `protobuf:"bytes,1,opt,name=params,proto3" json:"params,omitempty"`
 }


### PR DESCRIPTION
## Fix in `query.pb.go`

### Description
- Corrected a typo in the comment for `QueryParamsResponse`.
  - Updated `resposne` to `response` for clarity.
- No functional changes were made, only a documentation fix.

### Summary of Changes
- **File:** `x/globalfee/types/query.pb.go`
- **Change:**  
  ```diff
  - // QueryParamsResponse is the resposne for getting module's params.
  + // QueryParamsResponse is the response for getting module's params.
