### PR TITLE
expected_keepers.go

### DIFF
--- a/x/cron/types/expected_keepers.go
+++ b/x/cron/types/expected_keepers.go
@@ -10,6 +10,6 @@ import (
 type WasmKeeper interface {
 	// HasContractInfo checks if a contract with given address exists
 	HasContractInfo(ctx context.Context, contractAddr sdk.AccAddress) bool
-	// Sudo allows priviledged access to a contract
+	// Sudo allows privileged access to a contract
 	Sudo(ctx context.Context, contractAddress sdk.AccAddress, msg []byte) ([]byte, error)
 }


### PR DESCRIPTION
## Fix Typo in `expected_keepers.go`

### Changes
- Corrected a typo in the comment: replaced "priviledged" with "privileged."
