### PR TITLE
fix duplicated events

### DIFF
--- a/x/cron/abci.go
+++ b/x/cron/abci.go
@@ -54,7 +54,6 @@ func abciContractCallback(parentCtx sdk.Context, w types.WasmKeeper, msg contrac
 			)
 			return false // return without commit
 		}
-		parentCtx.EventManager().EmitEvents(ctx.EventManager().Events())
 		commit()
 		return false
 	}


### PR DESCRIPTION
Events are automatically emitted back to the parent context on write/commit