### PR TITLE
Fix typos in comments 

### DIFF
--- a/x/globalfee/types/tx.pb.go
+++ b/x/globalfee/types/tx.pb.go
@@ -352,7 +352,7 @@ func (m *MsgRemoveContractAuthorization) GetContractAddress() string {
 	return ""
 }
 
-// MsgRemoveContractAuthorizationResponse is the repsonse for executing a contract authorization removal.
+// MsgRemoveContractAuthorizationResponse is the response for executing a contract authorization removal.
 type MsgRemoveContractAuthorizationResponse struct {
 }
 
@@ -445,7 +445,7 @@ func (m *MsgUpdateParams) GetParams() Params {
 	return Params{}
 }
 
-// MsgUpdateParamsResponse is the response for executiong a module's params update.
+// MsgUpdateParamsResponse is the response for execution a module's params update.
 type MsgUpdateParamsResponse struct {
 }
 


### PR DESCRIPTION
Title:
Fix typos in comments for MsgRemoveContractAuthorizationResponse and MsgUpdateParamsResponse

Description:
This pull request corrects minor typos in the comments for the MsgRemoveContractAuthorizationResponse and MsgUpdateParamsResponse structs in x/globalfee/types/tx.pb.go. 